### PR TITLE
Fixed a typo: "Let's" -> "Lets"

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -378,7 +378,7 @@ Ctrl + E  Go to the end of the line you are currently typing on
 Ctrl + L  Clears the Screen, similar to the clear command
 Ctrl + U  Clears the line before the cursor position. If you are at the end of the line, clears the entire line.
 Ctrl + H  Same as backspace
-Ctrl + R  Let’s you search through previously used commands
+Ctrl + R  Lets you search through previously used commands
 Ctrl + C  Kill whatever you are running
 Ctrl + D  Exit the current shell
 Ctrl + Z  Puts whatever you are running into a suspended background process. fg restores it.


### PR DESCRIPTION
"Let's" is a contraction of "let us", as in "let's use shortcuts".

"Lets" is a form of "let", meaning "allow".