### PR TITLE
Fix " force quit a program" to send SIGKILL

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -309,7 +309,7 @@ $ bc
 **STOP CTRL + ALT + DELETE and choose the program to kill** :-1:
 
 ```shell
-$ killall program_name
+$ killall -9 program_name
 ```
 
 ## check server response


### PR DESCRIPTION
Running `killall program_name` sends a SIGTERM signal, which a program is free to ignore:
> If no signal name is specified, SIGTERM is sent.
https://man7.org/linux/man-pages/man1/killall.1.html

To send a SIGKILL signal, you need to use `killall -9` or `killall -KILL`, which cannot be ignored.