### PR TITLE
add -l to bc

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -301,7 +301,7 @@ $ date -j -v+7d                                               # on MacOS
 **STOP USING CALCULATOR WIDGET** :-1:
 
 ```shell
-$ bc
+$ bc -l
 ```
 
 ## force quit a program


### PR DESCRIPTION
-l makes bc works with float numbers, which are expected behavior for most users:
```
~ bc
bc 1.07.1
Copyright 1991-1994, 1997, 1998, 2000, 2004, 2006, 2008, 2012-2017 Free Software Foundation, Inc.
This is free software with ABSOLUTELY NO WARRANTY.
For details type `warranty'. 
3/2
1
~ bc -l
bc 1.07.1
Copyright 1991-1994, 1997, 1998, 2000, 2004, 2006, 2008, 2012-2017 Free Software Foundation, Inc.
This is free software with ABSOLUTELY NO WARRANTY.
For details type `warranty'. 
3/2
1.50000000000000000000
```